### PR TITLE
100x performance increase by improving namedEmoji map.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,7 @@ interface Window {
 
 const namedEmojiString = /*##EMOJILIST*/'';
 const namedEmoji = namedEmojiString.split(/,/);
-const namedMatchHash: { [key: string]: boolean } = namedEmoji.reduce(
-  (memo, v) => ({
-    ...memo,
-    [v]: true,
-  }),
-  {},
-);
+const namedMatchHash = new Set(namedEmoji);
 
 const emoticons = {
   /* :..: */ named: /:([a-z0-9A-Z_-]+):/,
@@ -185,7 +179,7 @@ class Emojify {
     /* Special case for named emoji */
     if (match[1] && match[2]) {
       var named = match[2];
-      if (namedMatchHash[named]) {
+      if (namedMatchHash.has(named)) {
         return named;
       }
       return;


### PR DESCRIPTION
The startup time of this script is abysmal, due the way `.reduce` is used to create a map of emoji names. Using a `Set` is way faster.

This issue slows down the loading of codimd significantly! Previously it spend ~680ms on initializing the emoji handling. After this change, this is down to <10ms. This is a total page-load-time improvement of ~33%.